### PR TITLE
PHP 8.1 Passing null deprecation

### DIFF
--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -144,7 +144,7 @@ class ConfigProvider
                 self::STAMPED_CORE_REWARDS_TRIGGER_STATUS,
                 ScopeInterface::SCOPE_STORE,
                 $storeId
-            )
+            ) ?: ''
         ));
     }
 
@@ -160,7 +160,7 @@ class ConfigProvider
                 self::STAMPED_CORE_ORDER_STATUS,
                 ScopeInterface::SCOPE_STORE,
                 $storeId
-            )
+            ) ?: ''
         ));
     }
 

--- a/Model/ConfigProvider.php
+++ b/Model/ConfigProvider.php
@@ -140,7 +140,7 @@ class ConfigProvider
     {
         return array_filter(explode(
             ',',
-            $this->scopeConfig->getValue(
+            (string) $this->scopeConfig->getValue(
                 self::STAMPED_CORE_REWARDS_TRIGGER_STATUS,
                 ScopeInterface::SCOPE_STORE,
                 $storeId
@@ -156,7 +156,7 @@ class ConfigProvider
     {
         return array_filter(explode(
             ',',
-            $this->scopeConfig->getValue(
+            (string) $this->scopeConfig->getValue(
                 self::STAMPED_CORE_ORDER_STATUS,
                 ScopeInterface::SCOPE_STORE,
                 $storeId

--- a/README.md
+++ b/README.md
@@ -4,5 +4,18 @@ Latest working extension for Magento version 2.x
 
 Installation Instructions:
 
-> Stamped Module for Magento 2, you need to unzip it and place it in app/code folder
+> Stamped Module for Magento 2, you need to unzip it and place it in the app/code directory.
+
+...
+src
+├── app
+|   ├── code
+|   |   ├── stamped 
+|   |   |   ├── core
+|   |   |   |   ├── ...
+|   |   |   |   ├── composer.json
+|   |   |   |   ├── README.md
+|   |   |   |   ├── registration.php
+└── ...
+
 <br> > then run setup upgrade command : php bin/magento setup:upgrade

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,5 @@
             "Stamped\\Core\\": ""
         }
     },
-    "version": "1.2.5"
+    "version": "1.2.6"
 }


### PR DESCRIPTION
Fixes the error in ConfigProvider.php:
`Passing null to parameter #2 ($string) of type string is deprecated` from PHP 8.1 deprecation.