### PR TITLE
Changes http client to Laminas instead of deprecated ZendClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,5 @@
             "Stamped\\Core\\": ""
         }
     },
-    "version": "1.2.7"
+    "version": "1.3.0"
 }

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,5 @@
             "Stamped\\Core\\": ""
         }
     },
-    "version": "1.2.6"
+    "version": "1.2.7"
 }


### PR DESCRIPTION
Updates the module to use Laminas for all http requests.
See [https://docs.laminas.dev/laminas-http/client/intro/](https://docs.laminas.dev/laminas-http/client/intro/)